### PR TITLE
conn/usb: Shadowed error can lead to null pointer deref

### DIFF
--- a/conn/usb/conn.go
+++ b/conn/usb/conn.go
@@ -53,7 +53,9 @@ func OpenUSB(address string) (io.ReadWriteCloser, error) {
 			err = fmt.Errorf("invalid device address. address should \"0x0000\" form")
 			goto handleError
 		}
-		productID, err := hex.DecodeString(address[2:])
+
+		var productID []byte
+		productID, err = hex.DecodeString(address[2:])
 		if err != nil {
 			goto handleError
 		}


### PR DESCRIPTION
When the access to the usb device failes given an explicit usb device it can lead to the error variable err being shadowed. This is now followed by a `goto handleError` which will return the original (nil) err instead of the thrown one.
```
	ser, err = ptouchgo.Open("usb://0x2061", 0, true)
```
Here err can never be non nil. We therefore must not shadow the original error for the codeflow to work.